### PR TITLE
main: use python3 shebang

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 from __future__ import division, absolute_import, print_function, unicode_literals
 import sys
 


### PR DESCRIPTION
I was running it as `./main.py` and it was still using python2, so not finding pyface, etc...